### PR TITLE
skip package-lock json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+package-lock.json


### PR DESCRIPTION
skipping package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude `package-lock.json` from version control. This change streamlines dependency management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->