### PR TITLE
Modal confirmation prop interface

### DIFF
--- a/src/components/modals/ModalConfirmation.tsx
+++ b/src/components/modals/ModalConfirmation.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Modal } from '@mui/material';
+import { ModalConfirmationProps } from 'lib/interfaces/modal';
 import React, { useState } from 'react';
 
 const style = {
@@ -14,7 +15,7 @@ const style = {
   pb: 3,
 };
 
-const ModalConfirmation = ({ children, buttonContent, confirm }: { children: any; buttonContent: any; confirm: any }) => {
+const ModalConfirmation = ({ children, buttonContent, confirm }: ModalConfirmationProps) => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => {
     setOpen(true);

--- a/src/lib/interfaces/modal.ts
+++ b/src/lib/interfaces/modal.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+export interface ModalConfirmationProps {
+  children: ReactNode;
+  buttonContent: ReactNode | string;
+  confirm: () => void;
+}


### PR DESCRIPTION
Fix #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced type safety for the `ModalConfirmation` component by introducing a structured `ModalConfirmationProps` interface
	- Replaced inline type definitions with a more explicit and clear type declaration for component props

<!-- end of auto-generated comment: release notes by coderabbit.ai -->